### PR TITLE
Exceptions and improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ cache: bundler
 rvm:
   - ruby
   - 2.1.2
+  - 2.2.2
+
+script: bundle exec rspec
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ Or install it yourself as:
 
 ```ruby
 require 'infobip/twofactor'
-@twofactor = Infobip::Twofactor::API.new("username", "password", "http://oneapi-test.infobip.com/2fa/1", "message_id", "application_id")
-
- => #<Infobip::Twofactor::API:0x007fcce1e7efe0 @authorization_string="aXBwZ4r3rOjRA34tLMipf", @auth=#<Crib::API:0x007fcce1e7ee78 @_agent=<Sawyer::Agent http://oneapi-test.infobip.com/2fa/1>, @_last_response=#<Sawyer::Response: 200 @rels={} @data="\"d02f4d9a2d9fb5a70b827819823254b8-9d48e592-db4a-4a70-95f0-59b3449f48d4\"">>, @api_key="d02f4d9a2d9fb5a723827819823254b8-9d48e592-db4a-4a70-95f0-59b5a49f4edd4", @api=#<Crib::API:0x007fcce1f8c0b8 @_agent=<Sawyer::Agent http://oneapi-test.infobip.com/2fa/1>>>
+@twofactor = Infobip::Twofactor::API.new("username", "password", "message_id", "application_id")
 
 @twofactor.send_pin("phone")
 

--- a/configuration.yml.example
+++ b/configuration.yml.example
@@ -1,5 +1,4 @@
 username:  "username"
 password: "password"
-url: "http://oneapi-test.infobip.com/2fa/1"
 application_id: "application id"
 message_id: "message id"

--- a/lib/infobip/twofactor/api.rb
+++ b/lib/infobip/twofactor/api.rb
@@ -14,7 +14,7 @@ module Infobip
       attr_reader :application_id
       attr_reader :message_id
 
-      def initialize(username, password, url, message_id, application_id)
+      def initialize(username, password, message_id, application_id)
         raise(ArgumentError, "Missing message_id") unless message_id
         raise(ArgumentError, "Missing application_id") unless application_id
         @message_id = message_id

--- a/lib/infobip/twofactor/api.rb
+++ b/lib/infobip/twofactor/api.rb
@@ -11,49 +11,73 @@ module Infobip
       attr_reader :message_id
 
       def initialize(username, password, url, message_id, application_id)
-        raise "Missing message_id" unless message_id
-        raise "Missing application_id" unless application_id
+        raise(ArgumentError, "Missing message_id") unless message_id
+        raise(ArgumentError, "Missing application_id") unless application_id
         @message_id = message_id
         @application_id = application_id
         @url = url
-        uri = URI.parse(@url+"/api-key")
+        uri = URI.parse(@url + "/api-key")
         @http = Net::HTTP.new(uri.host, 443)
         @http.use_ssl = true
         request = Net::HTTP::Post.new(uri.path)
-        request.basic_auth(username,password)
+        request.basic_auth(username, password)
         request["content-type"] = "application/json"
         @api_key = @http.request(request).body.gsub('"','')
       end
 
       def send_pin(phone)
-        raise "Missing phone number" unless phone
-        raise "Missing message_id" unless @message_id
-        raise "Missing application_id" unless @application_id
-        uri = URI.parse(@url+"/pin")
+        raise(ArgumentError, "Missing phone number") unless phone
+        raise(ArgumentError, "Missing message_id") unless @message_id
+        raise(ArgumentError, "Missing application_id") unless @application_id
+        uri = URI.parse(@url + "/pin")
         request = Net::HTTP::Post.new(uri.path)
         request["authorization"] = "App #{@api_key}"
         request["content-type"] = "application/json"
-        request.body = {applicationId: @application_id, messageId: @message_id, to: phone}.to_json
-        response = JSON.parse @http.request(request).body
-        raise "Malformed two factor API response - no sms status field. Response was: #{response.inspect}" if (response["smsStatus"].nil?)
-        raise "Malformed two factor API response - no pin Id field. Response was: #{response.inspect}" if (response["pinId"].nil?)
-        raise "SMS not sent" unless (response["smsStatus"] == "MESSAGE_SENT")
-        @pin_id = response["pinId"]
-        response
+        request.body = { applicationId: @application_id, messageId: @message_id, to: phone }.to_json
+        response = @http.request(request)
+        response_hash = JSON.parse(response.body)
+
+        if response.code == "200"
+          raise("Malformed API response - no smsStatus field. Response was: #{response_hash.inspect}") if response_hash["smsStatus"].nil?
+          raise("Malformed API response - no pinId field. Response was: #{response_hash.inspect}") if response_hash["pinId"].nil?
+          raise("SMS not sent") if response_hash["smsStatus"] == "MESSAGE_NOT_SENT"
+          return response_hash
+        else
+          handle_error_response(response)
+        end
       end
 
       def verify_pin(pin_id, pin)
-        raise "Missing pin id" unless pin_id
-        uri = URI.parse(@url+"/pin/#{pin_id}/verify")
+        raise("Missing pin id") unless pin_id
+        uri = URI.parse(@url + "/pin/#{pin_id}/verify")
         request = Net::HTTP::Post.new(uri.path)
         request["content-type"] = "application/json"
         request["authorization"] = "App #{@api_key}"
-        request.body = {pin: pin}.to_json
-        response = JSON.parse @http.request(request).body
-        raise "Malformed two factor API response - no verified field. Response was: #{response.inspect}" if (response["verified"].nil?)
-        response
+        request.body = { pin: pin }.to_json
+        response = @http.request(request)
+        response_hash = JSON.parse(response.body)
+
+        if response.code == "200"
+          raise "Malformed API response - no verified field. Response was: #{response_hash.inspect}" if response_hash["verified"].nil?
+          return response_hash
+        else
+          handle_error_response(response)
+        end
       end
 
+      private
+      def handle_error_response(response)
+        case response.code
+        when "400" then raise("Bad request")
+        when "401" then raise("User unauthorized")
+        when "404" then raise("Method not found")
+        when "429" then raise("Too many requests to the API")
+        when "500" then raise("Internal server error")
+        when "503" then raise("Service unavailable")
+        else
+          raise("Unexpected response code: #{response.code}")
+        end
+      end
     end
   end
 end

--- a/spec/twofactor_api_spec.rb
+++ b/spec/twofactor_api_spec.rb
@@ -12,7 +12,7 @@ describe Infobip::Twofactor::API do
     FakeWeb.register_uri(:post, "https://ippdok:4%40SkK2*_@oneapi.infobip.com/2fa/1/api-key",  status: ["200", "OK"], body: api_key_response_body)
     FakeWeb.register_uri(:post, "https://oneapi.infobip.com/2fa/1/pin",  response: api_send_pin_response)
     FakeWeb.register_uri(:post, "https://oneapi.infobip.com/2fa/1/pin/2B29B71922B37D3C93F8CEBB85B9E3CF/verify", response: api_verify_pin_response)
-    @twofactor = Infobip::Twofactor::API.new(@configuration["username"], @configuration["password"], @configuration["url"], @configuration["message_id"], @configuration["application_id"])
+    @twofactor = Infobip::Twofactor::API.new(@configuration["username"], @configuration["password"], @configuration["message_id"], @configuration["application_id"])
   end
 
   subject { @twofactor }


### PR DESCRIPTION
I've improved exception handling - now request limit error is readable, added custom handling for other errors as well. Moreover, I've moved the request initialization to a private method to DRY it all up, and included the API host and base path into the gem, as we previously discussed, which makes it unnecessary to specify that attribute on `Infobip::Twofactor::API` initialization. This is, however, a breaking change.